### PR TITLE
Add macros for AES block size

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -14,6 +14,9 @@
 
 #define DPU_DATA_SIZE dpu_data_size
 
+#define AES_BLOCK_SIZE 128
+#define AES_BLOCK_SIZE_BYTES (AES_BLOCK_SIZE / 8)
+
 #define AES_KEY_SIZE 128
 #define AES_KEY_SIZE_BYTES (AES_KEY_SIZE / 8)
 

--- a/dpu/dpu.c
+++ b/dpu/dpu.c
@@ -21,8 +21,9 @@
 
 #define NR_CRYPTO_TASKLETS (NR_TASKLETS - 1)
 #define CRYPTO_START_OFFSET                                                    \
-  ((me() - 1) * 16) // crypto tasklet 1 starts on block 0, crypto tasklet 2
+  ((me() - 1) * AES_BLOCK_SIZE_BYTES) // crypto tasklet 1 starts on block 0, crypto tasklet 2
                     // starts on block 1...
+#define CRYPTO_INTERVAL (NR_CRYPTO_TASKLETS * AES_BLOCK_SIZE_BYTES)
 
 __mram_noinit uint8_t DPU_BUFFER[DPU_BUFFER_SIZE];
 __host perfcounter_t dpu_perfcount;
@@ -74,7 +75,7 @@ int do_crypto(void) {
     uint8_t *start_block = transfer_buffers[current_buffer].data;
     for (uint8_t *block_ptr = start_block + CRYPTO_START_OFFSET;
          block_ptr < start_block + TRANSFER_SIZE;
-         block_ptr += 16 * NR_CRYPTO_TASKLETS) {
+         block_ptr += CRYPTO_INTERVAL) {
 #ifndef DECRYPT
       AES_encrypt(block_ptr, block_ptr, &key);
 #else

--- a/host/host.c
+++ b/host/host.c
@@ -6,11 +6,13 @@
 #include <string.h>
 #include <stdlib.h>
 
+#define LONGS_PER_AES_BLOCK (AES_BLOCK_SIZE_BYTES / sizeof(unsigned long long))
+
 #define TESTDATA_FOREACH_BLOCK(block_var, index_var)                           \
   for (unsigned long long block_var = 0, index_var = 0;                        \
        block_var < (test_data_size / sizeof(unsigned long long)) /             \
-                       (16 / sizeof(unsigned long long));                      \
-       block_var++, index_var += 16 / sizeof(unsigned long long))
+                       (LONGS_PER_AES_BLOCK);    \
+       block_var++, index_var += LONGS_PER_AES_BLOCK)
 
 #define USAGE "Usage: pimcrypto [data_length] [number_of_dpus]" \
   "\n\ndata_length may not be 0, and may use K, M, or G to indicate units.\n" \

--- a/host/pim_crypto.c
+++ b/host/pim_crypto.c
@@ -14,7 +14,7 @@ int dpu_AES_ecb(void *in, void *out, unsigned long length, const void *key,
     return -1;
   }
 
-  if (length % 128 != 0) {
+  if (length % AES_BLOCK_SIZE_BYTES != 0) {
     ERROR("Length is not a multiple of block size\n");
     return -1;
   }
@@ -50,7 +50,7 @@ int dpu_AES_ecb(void *in, void *out, unsigned long length, const void *key,
     return -1;
   }
 
-  if (chunk_size % 128 != 0) { // Some blocks are not whole
+  if (chunk_size % AES_BLOCK_SIZE_BYTES != 0) { // Some blocks are not whole
     ERROR("Length is not a multiple of block size when split across %d DPUs\n", real_nr_dpus);
     DPU_ASSERT(dpu_free(dpu_set));
     return -1;


### PR DESCRIPTION
This clarifies the code in lots of places, as well as fixing a bug in
`dpu_AES_ecb()` where the block size in bits was compared to input
length in bytes, causing `dpu_AES_ecb()` to reject lengths that were not
multiples of 128 (proper behavior is to reject lengths that are not
multiples of 16).

Fixes #12